### PR TITLE
Localstore spike

### DIFF
--- a/4628util.user.js
+++ b/4628util.user.js
@@ -27,28 +27,35 @@ function main() {
 
     // 出勤簿を開いた際に始業・就業時間をローカルストレージに保持させる
     if ($(".main_header").html() && $(".main_header").html().match(/\u51FA\u52E4\u7C3F/)) {
+      var workingTime = $('#title_on0').html().match(/[0-9]+/g);
+      if (workingTime.length == 2) {
+        // "みなし（東京9-18）"といった形で始業時間が記載されている場合
+        for (i=0; i<workingTime.length; i++) {
+          fetchTime = workingTime[i];
 
-      if ($('.user_name').html().match(/\u6771\u4eac|\u4eac\u90fd/)) {
-        if ($('#title_on0').html().match(/9\-18/)) {
-          // 東京タイム(09:00-18:00)
-          var defaultStartHour = "09";
-          var defaultEndHour   = "18";
-        } else {
-          // 東京、京都タイム(10:00-19:00)
-          var defaultStartHour = "10";
-          var defaultEndHour   = "19";
+          if (fetchTime.length == 1) {
+            fetchTime = "0" + fetchTime;
+          } else if (fetchTime.length == 4) {
+            fetchTime = fetchTime.substr(0,2);
+          }
+
+          if (i==0) {
+            var defaultStartHour = fetchTime;
+          } else {
+            var defaultEndHour = fetchTime;
+          }
         }
       } else {
-        // 福岡タイム
-        var defaultStartHour = "09";
-        var defaultEndHour   = "18";
+        // 時間表記が無いので9:00-18:00を標準とする
+        var defaultStartHour = 9;
+        var defaultEndHour = 18;
       }
 
       // ローカルストレージに保管
       window.localStorage.setItem("startHour", defaultStartHour);
       window.localStorage.setItem("endHour", defaultEndHour);
     }
-    
+
     // 残業開始時間セット
     var defaultStartHour = window.localStorage.getItem("startHour");
     var defaultEndHour   = window.localStorage.getItem("endHour");


### PR DESCRIPTION
- 東京の始業時間が2通りになった点に対応するために勤務表画面を開いた際にブラウザのローカルストレージに始業・就業時間を保持する様に修正してみました。
  - 始業開始時間は勤務表の"みなし（東京9-18）"といった表記から判定させました。
  - MacのChrome, Firefoxで確認しました。(東京9時始業のパタン)
