### PR TITLE
午後休・午前休の申請忘れを防止するため、実働が8時間未満だったら休暇申請のリンクを出す。

### DIFF
--- a/4628util.user.js
+++ b/4628util.user.js
@@ -149,7 +149,7 @@ function main() {
                      + "&month=" + dispMonth
                      + "&day=" + day;
         
-        if ($(this).attr("id") == 1) {
+        if ($(this).attr("name") == 1) {
           // 残業申請の場合、退社時間をクエリストリングに追加
           var endTime = $("td", $(this).parent().parent()).eq(7).html();
           if (endTime.match(/\d\d:\d\d/)) {


### PR DESCRIPTION
htmlのidは被らない方がいいのでnameに変更。
（※休暇申請のIDは女性は25と分かりましたが男性用は分かりませんでした…。）
